### PR TITLE
試合実行中にアーカイブされたグループを削除可能に修正

### DIFF
--- a/server/group/views_admin.py
+++ b/server/group/views_admin.py
@@ -260,7 +260,16 @@ def archive_groups():
         group.is_active = False
         matches_in_group = Match.query.filter_by(group_id=group_id).all()
         for match in matches_in_group:
-            if match.status == MatchStatus.IN_PROGRESS or match.status == MatchStatus.UNEXECUTED:
+            if match.status == MatchStatus.IN_PROGRESS:
+                match.host.assigned_match_id = None
+                match.host_id = None
+                match.host_name = None
+                match.host_name = None
+                match.start_time = None
+                match.status = MatchStatus.ARCHIVED
+                match.log_file_name = None
+                match.token = None
+            elif match.status == MatchStatus.UNEXECUTED:
                 match.status = MatchStatus.ARCHIVED
         try:
             db.session.commit()
@@ -347,11 +356,11 @@ def delete_groups():
             current_app.logger.error(f"Group ID {group.name} is active. Cannot delete.")
             continue
 
-        # matches = Match.query.filter_by(group_id=group_id)
+        # matches = group.matches
         # if matches:
         #     matches.delete()
 
-        # stats = GroupStats.query.filter_by(group_id=group_id)
+        # stats = group.stats
         # if stats:
         #     stats.delete()
 

--- a/server/host/models.py
+++ b/server/host/models.py
@@ -18,7 +18,8 @@ class Host(db.Model):
     assigned_match_id = db.Column(db.Integer,
                                   db.ForeignKey("match.id",
                                                 use_alter=True,
-                                                name="fk_host_match_id"),
+                                                name="fk_host_match_id",
+                                                ondelete="SET NULL"),
                                   nullable=True)
 
     # stats is a one-to-one relationship with HostStats


### PR DESCRIPTION
- アーカイブ処理時にin progressな試合レコードの属性をリセットするように変更
- 紐付けられたHostのassigned_match_idをNoneにセットするように変更
- Hostのassigned_match_idに ondelete="SET NULL" オプションを追加